### PR TITLE
Typo error on openrc-misc/clamav.install

### DIFF
--- a/openrc-misc/clamav.install
+++ b/openrc-misc/clamav.install
@@ -1,4 +1,4 @@
-_svc="calmd"
+_svc="clamd"
 _rlvl="default"
 
 post_install() {


### PR DESCRIPTION
There was a typo on first line of openrc-misc/clamav.install; it says _svc="calmd" and should be _svc="clamd". Fixed.