### PR TITLE
Allow nonversioned *.conf in /etc/modules-load.d

### DIFF
--- a/openrc/PKGBUILD
+++ b/openrc/PKGBUILD
@@ -30,7 +30,7 @@ source=("${pkgname}-${pkgver}.tar.gz::${_url}/${pkgver}.tar.gz"
 	'use-optional-modules-load-d.patch')
 sha256sums=('3929193306f6033547331f65bcddb01c23edc770f725cc4750a252574b66aef4'
             '0b44210db9770588bd491cd6c0ac9412d99124c6be4c9d3f7d31ec8746072f5c'
-            '54e0cfb59b83ad42ec85486b99b7fed52ccbc8f98f0f113668eacf48a24a2d03')
+            'b8b750c863199e9c039e874c3c79c72d468f35442750156dfbdf503a27977cf3')
 
 if [ -f /etc/lsb-release ]; then
     . /etc/lsb-release

--- a/openrc/use-optional-modules-load-d.patch
+++ b/openrc/use-optional-modules-load-d.patch
@@ -1,5 +1,6 @@
---- ../conf.d/modules.orig	2015-07-06 01:50:49.893895158 +0200
-+++ ../conf.d/modules	2015-07-06 01:27:49.000000000 +0200
+diff -aur openrc-0.20.5.orig/conf.d/modules openrc-0.20.5/conf.d/modules
+--- openrc-0.20.5.orig/conf.d/modules	2016-04-20 10:54:37.686042847 -0700
++++ openrc-0.20.5/conf.d/modules	2016-04-20 10:56:27.900232387 -0700
 @@ -1,6 +1,11 @@
  # You can define a list modules for a specific kernel version,
  # a released kernel version, a main kernel version or just a list.
@@ -12,39 +13,65 @@
  #modules_2_6_23_gentoo_r5="ieee1394 ohci1394"
  #modules_2_6_23="tun ieee1394"
  #modules_2_6="tun"
-
---- ../init.d/modules.in.orig	2015-06-19 16:55:37.000000000 +0200
-+++ ../init.d/modules.in	2015-07-06 01:30:29.154313412 +0200
-@@ -16,6 +16,35 @@
+diff -aur openrc-0.20.5.orig/init.d/modules.in openrc-0.20.5/init.d/modules.in
+--- openrc-0.20.5.orig/init.d/modules.in	2016-04-20 10:54:37.689376105 -0700
++++ openrc-0.20.5/init.d/modules.in	2016-04-20 10:55:41.671271452 -0700
+@@ -23,6 +23,61 @@
  	# support compiled in ...
  	[ ! -f /proc/modules ] && return 0
-
-+	if ${use_modules_load_d};then
+ 
++	if yesno "${use_modules_load_d:-false}";then
 +		local conf_s=/etc/modules-load.d
 +		einfo "using ${conf_s}"
-+		local conf_rc=/etc/conf.d/modules
-+		mv ${conf_rc} ${conf_rc}.lastboot
-+		touch ${conf_rc}
-+		echo "use_modules_load_d=${use_modules_load_d}" >> ${conf_rc}
-+		if [[ -d ${conf_s} ]] && [[ -f ${conf_s}/mhwd-gpu.conf ]]; then
-+			local mods=() mhwd=() fn= kv=
++
++		local mhwd=
++		if [ -f "${conf_s}/mwhd-gpu.conf" ];then
 +			for m in $(cat ${conf_s}/mhwd-gpu.conf | sed '/^.*#/d'); do
-+				mhwd+=("$m")
++				mhwd="$mhwd $m"
 +			done
++		fi
++
++		if [ -d "${conf_s}" ]; then
++			local mods= fn= kv= gmods= kv_cache=
++
 +			for f in $(ls ${conf_s}/*.conf); do
-+				if [[ $fn != mhwd-gpu ]];then
-+					fn=${f##*/}
-+					fn=${fn%%.conf}
-+					kv=${fn//-*}
-+					kv=${kv##linux}
-+					for m in $(cat $f | sed '/^.*#/d'); do
-+						mods+=("$m")
-+					done
-+					[[ $fn == linux${kv}-* ]] && echo 'modules_'${kv:0:1}'_'${kv:1:2}'="'${mods[@]} ${mhwd[@]}'"' >> ${conf_rc}
-+					echo '' >> ${conf_rc}
-+					mods=()
++				fn="$( expr "$(basename "$f")" : '\(.*\).conf' )"
++
++				if [ "$fn" != mhwd-gpu ];then
++					kv="$(expr "$fn" : 'linux\([0-9]\+\)-')"
++					echo "$fn || $kv"
++
++					if expr "$fn" : "linux${kv}-.*" > /dev/null; then
++						for m in $(cat $f | sed '/^.*#/d'); do
++							mods="$mods $m"
++						done
++
++						local kv_major="$(expr "$kv" : "\([0-9]\)" )"
++						local kv_minor="$(expr "$kv" : "[0-9]\([0-9]\)" )"
++
++						local kvr_k="${kv_major}_${kv_minor}"
++
++						if expr \( "${kv_cache}" : "${kvr_k}" \) = 0; then
++							kv_cache="${kv_cache} ${kvr_k}"
++						fi
++
++						eval local "_cache_${kvr_k}=\"\${_cache_${kvr_k}} ${mods}\""
++						mods=
++					else
++						for m in $(cat $f | sed '/^.*#/d'); do
++							gmods="$gmods $m"
++						done
++					fi
 +				fi
 +			done
++
++			for kv_key in $(echo "${kv_cache}"|tr ' ' '\n'); do
++				kv_val="$(eval "echo \"\${_cache_${kv_key}}"\")"
++				eval "modules_${kv_key}=\"${kv_val} ${mhwd} ${gmods}\""
++				unset "_cache_${kv_key}"
++			done
++
++			eval "modules=\"${mhwd} ${gmods}\""
 +		fi
 +	fi
 +


### PR DESCRIPTION
## Commit Notes

The following patches several things that were not ideal or buggy in the previous implementation:

- Lots of Bashisms. openrc-run scripts should always be POSIX compliant
  in case other distros using OpenRC with a non-bash sh want to use it.
- Do not require mwhd-gpu.conf to use /etc/modules-load.d autoload
- Properly update the list of kernel modules for a specific version
- Avoid destructively overwriting /etc/conf.d/modules. What this does
  instead is it overrides any variables that may've been specified in
  /etc/init.d/modules.
- Avoid directly evaluating ${use_modules_load_d}. There's a yesno
  builtin that easily allows checking boolean values.

----

## Misc

I wrote the fix for a patch as a standalone shellscript so I could test it without putting the change directly in `/etc/init.d/modules`. That being said, please be sure to also test it with a dummy OpenRC install to make sure this does not break anything.