### PR TITLE
Fixed PKGBUILD

### DIFF
--- a/lib32-eudev/PKGBUILD
+++ b/lib32-eudev/PKGBUILD
@@ -16,7 +16,7 @@ provides=("lib32-udev=${_udevver}" "lib32-systemd=${_udevver}")
 conflicts=('lib32-systemd' 'libudev.so')
 options=(!makeflags !libtool)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/gentoo/eudev/archive/v${pkgver}.tar.gz")
-sha256sums=('d84a5f7942393a009afc6af0bf31e98841147a0521b91ffbed161dccac303c25')
+sha256sums=('37829d37f4beb7e358ca33abc1ad0907d87f917ce157777aeaeebeacae24efdc')
 
 build() {
 
@@ -25,6 +25,7 @@ build() {
     export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"
 
     cd "${srcdir}/${_pkgname}-${pkgver}"
+    ./autogen.sh
     ./configure \
 		--prefix=/usr \
         --with-rootprefix=/usr \


### PR DESCRIPTION
Fixed 2 issues.

The sha256 was wrong.

Also the file needs autogen.sh to be run which will create the configure script. The build fails without this.