### PR TITLE
update pkgrel and sums from upstream libsystemd

### DIFF
--- a/eudev-systemdcompat/PKGBUILD
+++ b/eudev-systemdcompat/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Dave Reisner <dreisner@archlinux.org>
 # Contributor: Tom Gundersen <teg@jklm.no>
 
-_spkgrel=3
+_spkgrel=4
 _repo=http://mirror.netcologne.de/archlinux/core/os
 
 pkgbase=eudev-systemdcompat
@@ -18,10 +18,10 @@ source_i686=("$_repo/i686/libsystemd-$pkgver-${_spkgrel}-i686.pkg.tar.xz"
 source_x86_64=("$_repo/x86_64/libsystemd-$pkgver-${_spkgrel}-x86_64.pkg.tar.xz"
 		"$_repo/x86_64/systemd-$pkgver-${_spkgrel}-x86_64.pkg.tar.xz"
 		"gummibootx64.efi")
-md5sums_i686=('1b3fa9059c12eba0bec92cb16435e20d'
-              'dcb3c973314fb38b968869d4b169c4bc')
-md5sums_x86_64=('a4e2fbd6645aacf4bba5aafa9a220c68'
-                '6d09efd13c1f16a7227e77c56af0d4e9'
+md5sums_i686=('e33f8c03adec815f9bece11ce623ed78'
+              'bcbec1e89db4a7a142f860cd6479ff4d')
+md5sums_x86_64=('f4ca6c04596a14fa720ce536a2aaf3ab'
+                '54ea61ad80b4929c1a98121ef93793c4'
                 'ef357b701d67fa39355cbc1c3b9d5afd')
 
 package_eudev-systemd() {

--- a/eudev-systemdcompat/PKGBUILD
+++ b/eudev-systemdcompat/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Dave Reisner <dreisner@archlinux.org>
 # Contributor: Tom Gundersen <teg@jklm.no>
 
-_spkgrel=1
+_spkgrel=3
 _repo=http://mirror.netcologne.de/archlinux/core/os
 
 pkgbase=eudev-systemdcompat
@@ -18,11 +18,11 @@ source_i686=("$_repo/i686/libsystemd-$pkgver-${_spkgrel}-i686.pkg.tar.xz"
 source_x86_64=("$_repo/x86_64/libsystemd-$pkgver-${_spkgrel}-x86_64.pkg.tar.xz"
 		"$_repo/x86_64/systemd-$pkgver-${_spkgrel}-x86_64.pkg.tar.xz"
 		"gummibootx64.efi")
-sha256sums_i686=('2f759a0864788357b4d27e77ebd743fbbf877c10a364bfb7b0dc004525b94e6a'
-                 '40c5c372e008931240ec3e059a4b06ac67a58d86d492e66d4abb5651fef9483b')
-sha256sums_x86_64=('a53e9c88112c2852b11410cdcd5365ce57e66b408a4a23195070c8fe4ab58a41'
-                   '5efc276863a80fe9fea8bbe7f3e2a33792f9ec6be5e5db21c55c028e889ac18d'
-                   'e0c6a40c74dc3a597dda977cb44bdf21759b8869e152d898d35664b8d3675fd3')
+md5sums_i686=('1b3fa9059c12eba0bec92cb16435e20d'
+              'dcb3c973314fb38b968869d4b169c4bc')
+md5sums_x86_64=('a4e2fbd6645aacf4bba5aafa9a220c68'
+                '6d09efd13c1f16a7227e77c56af0d4e9'
+                'ef357b701d67fa39355cbc1c3b9d5afd')
 
 package_eudev-systemd() {
 	pkgdesc="systemd-sysuser and systemd-tmpfiles binary; systemd compatibility package"


### PR DESCRIPTION
The upstream package for libsystemd is now at pkgrel 3. I have updated the pkgrel and the sums.