### PR TITLE
fixed regression with openrc-status and NM 1.6.0

### DIFF
--- a/networkmanager-consolekit/1.6.0-floating.patch
+++ b/networkmanager-consolekit/1.6.0-floating.patch
@@ -1,0 +1,12 @@
+diff -Naur NetworkManager-1.6.0-orig/clients/nm-online.c NetworkManager-1.6.0/clients/nm-online.c
+--- NetworkManager-1.6.0-orig/clients/nm-online.c	2017-01-16 11:08:37.000000000 -0300
++++ NetworkManager-1.6.0/clients/nm-online.c	2017-01-31 22:03:53.516699140 -0300
+@@ -223,7 +223,7 @@
+ 
+ 	remaining_ms = t_secs * 1000;
+ 	data.end_timestamp_ms = data.start_timestamp_ms + remaining_ms;
+-	data.progress_step_duration = (data.end_timestamp_ms - data.start_timestamp_ms + PROGRESS_STEPS/2) / PROGRESS_STEPS;
++	data.progress_step_duration = NM_MAX (1, (data.end_timestamp_ms - data.start_timestamp_ms + PROGRESS_STEPS/2) / PROGRESS_STEPS);
+ 
+ 	g_timeout_add (data.quiet ? remaining_ms : 0, handle_timeout, &data);
+ 	nm_client_new_async (NULL, got_client, &data);

--- a/networkmanager-consolekit/PKGBUILD
+++ b/networkmanager-consolekit/PKGBUILD
@@ -10,7 +10,7 @@ _pppver=2.4.7
 
 pkgname=networkmanager-consolekit
 pkgver=1.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Network Management daemon"
 arch=('i686' 'x86_64')
 license=('GPL2' 'LGPL2.1')
@@ -36,11 +36,13 @@ backup=('etc/NetworkManager/NetworkManager.conf')
 source=("https://download.gnome.org/sources/NetworkManager/${pkgver:0:3}/NetworkManager-$pkgver.tar.xz"
         'NetworkManager.conf'
         '01-org.freedesktop.NetworkManager.settings.modify.system.rules'
-        '50-org.freedesktop.NetworkManager.rules')
+        '50-org.freedesktop.NetworkManager.rules'
+        '1.6.0-floating.patch')
 sha256sums=('eabc8b03770411248d5301c52f6e12ba732f22b6c330c804335f2033cbde4339'
             '452e4f77c1de92b1e08f6f58674a6c52a2b2d65b7deb0ba436e9afa91ee15103'
             '4b815f43de58379e68653d890f529485aec4d2f83f11d050b08b31489d2267c2'
-            '02d9f7d836d297d6ddf39482d86a8573b3e41735b408aa2cd6df22048ec5f6c4')
+            '02d9f7d836d297d6ddf39482d86a8573b3e41735b408aa2cd6df22048ec5f6c4'
+            '76db3fb037514eb0a22bf9f222593ae9dc9ee952481cbed08bdac83cc1ea4a11')
 
 # pkgver() {
 #   cd NetworkManager
@@ -53,6 +55,8 @@ prepare() {
   2to3 -w libnm src tools
 
   NOCONFIGURE=1 ./autogen.sh
+
+  patch -Np1 -i ${srcdir}/1.6.0-floating.patch
 }
 
 build() {

--- a/openrc-desktop/10-openrc-status
+++ b/openrc-desktop/10-openrc-status
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Copyright (c) 2012 Alexandre Rostovtsev
+# Released under the 2-clause BSD license.
+
+# Ensures that the NetworkManager OpenRC service is marked as started and
+# providing net only when it has a successful connection.
+
+if [ ! -e "/run/openrc/softlevel" ]; then
+	# OpenRC is not running
+	exit 0
+fi
+
+# Ensure rc-service is in PATH
+PATH="${PATH}:/usr/bin:/usr/bin"
+
+# Exit if the NetworkManager OpenRC service is not running
+rc-service NetworkManager status 2>&1 | grep -Eq "status: (starting|started|inactive|stopping)" || exit 0
+
+# Call rc-service in background mode so that the start/stop functions update
+# NetworkManager service status to started or inactive instead of actually
+# starting or stopping the daemon
+export IN_BACKGROUND=YES
+
+case "$2" in
+	up) nm-online -t 0 -x ||
+		! rc-service NetworkManager status 2>&1 | grep -q started &&
+		exec rc-service NetworkManager start ;;
+	down) nm-online -t 0 -x ||
+		rc-service NetworkManager status 2>&1 | grep -q stopped ||
+		exec rc-service NetworkManager stop ;;
+	pre-sleep) rc-service NetworkManager status 2>&1 | grep -q stopped ||
+		exec rc-service NetworkManager stop ;;
+esac
+exit 0
+# vim: set ts=4:

--- a/openrc-desktop/PKGBUILD
+++ b/openrc-desktop/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=('acpid-openrc'
 		'networkmanager-openrc'
 		'wpa_supplicant-openrc')
 
-pkgver=20160623
+pkgver=20170201
 pkgrel=1
 pkgdesc="OpenRC init scripts"
 arch=('any')
@@ -43,7 +43,8 @@ source=("acpid.confd::${_url}/sys-power/acpid/files/acpid-2.0.16-conf.d"
 		"cgmanager.initd::${_url}/app-admin/cgmanager/files/cgmanager.initd-r1"
 		"NetworkManager.confd::${_url}/net-misc/networkmanager/files/conf.d.NetworkManager"
 		"NetworkManager.initd::${_url}/net-misc/networkmanager/files/init.d.NetworkManager"
-		"10-openrc-status::${_url}/net-misc/networkmanager/files/10-openrc-status-r4"
+		#"10-openrc-status::${_url}/net-misc/networkmanager/files/10-openrc-status-r4"
+		'10-openrc-status'
 		'avahi-daemon.initd'
 		'avahi-dnsconfd.initd'
 		'xdg-user-dirs')
@@ -68,7 +69,7 @@ sha256sums=('3755d4eb8bb64a1304e5defedb949305ac550565da36fe4f94d5f31beee821ba'
             '625c8b2f507076eac0108e75547239508d147bcc669372fc3991bb42b17608e1'
             '4594573f01fe5e04b6dde4525796acf909158591bdcefd662ec23fe0d1c3e1bd'
             '1af8436d6e917708ef310498c57272229e3f149cc7305281fb647c1e03fb952c'
-            'f8ed424818b866a0bf882c569f4484e8b1485ce7ac8c472f060fd877f2dcfe65'
+            '1535237db113a76261d6f1ce0b24a55e956934b0c1c59e9fd624f621961327b6'
             '876788303553fe773e64917f76f0208f5e8adf7b91d4af24aa9d6a68a147d646'
             'e128576d72981e402ff106bb481108ab6d5ba941ab1b0f5f53e96a7831fc1d15'
             'f0f27de23d849b2fa4ebf59e448b5a843b577d14dc2c1070e228999091fa7f5e')


### PR DESCRIPTION
There is a major bug that causes network problems with OpenRC on Network Manager 1.6.0. The nm-online command used in the openrc dispatcher script has a divide by 0 problem which causes a segfault. I have added the patch to get it working correctly. But there is also a second problem, because of the changes made to nm-online, the script had to be updated, the one from upstream gentoo for NM 1.4.4 does not work correctly with 1.6.0.

The bug causes the rc-status to always display "inactive" for NetworkManager even though the connection was successful. This also causes all openrc scripts that depend on a network connection to fail such as "netmount".

Reference to NM 1.6.0 division by 0:
https://github.com/NetworkManager/NetworkManager/commit/34acecf544b364a958f0ffadd88be52c5bdd63e5